### PR TITLE
Fix issues with Twin Analog example

### DIFF
--- a/examples/twin_analog/Play.pyxl
+++ b/examples/twin_analog/Play.pyxl
@@ -8,9 +8,9 @@ const bindings = {
 
 def draw_instructions():
    let y = 2
-   for control in bindings:
-      draw_text(font, control, xy(1, y), #abf, ∅, #00d)
-      draw_text(font, bindings[control], xy(70, y), #abf, ∅, #00d)
+   for control at name in bindings:
+      draw_text(font, name, xy(1, y), #abf, ∅, #00d)
+      draw_text(font, control, xy(70, y), #abf, ∅, #00d)
       y += 12
    draw_text(font, "TWIN ANALOG STICK EXAMPLE\n(nonstandard controls)", xy(½ SCREEN_SIZE.x, SCREEN_SIZE.y), 
       #fff, ∅, #800, "center", "top") 

--- a/examples/twin_analog/player.pyxl
+++ b/examples/twin_analog/player.pyxl
@@ -38,7 +38,7 @@ def analog_stick(index):
    const stick = device_control("get_analog_axes", index)
    const dpad = gamepad_array[index].xy
    const result = xy(0, 0)
-   for axis in "xy":
+   for axis in ["x", "y"]:
       result[axis] = if (|stick[axis]| > THRESHOLD) then stick[axis] else dpad[axis]
    return result
    
@@ -92,7 +92,7 @@ def simulate_player():
       
 
 def simulate_player_bullets():
-   for pos, vel, life in bullet in player_bullet_array:
+   for pos, vel, life in bullet in clone(player_bullet_array):
       if life > 0:
          --life
          pos += vel


### PR DESCRIPTION
1. Fixed crashes on startup and fire
2. Fix control display

There are some additional issues that need to fixed as well, such as:
1. `for char in string:` not working (caused startup crash)
2. `device_control("get_analog_axes", index)` doesn't seem to give analog values, at least with my Xbox One controller and Microsoft Edge (Chromium).