### PR TITLE
Prefer using py.exe Python launcher on Windows

### DIFF
--- a/quadplay.cmd
+++ b/quadplay.cmd
@@ -1,2 +1,10 @@
-@rem Python 3 is called "python" on Windows(!)
-@python quadplay %*
+@rem Check if "py.exe" launcher is installed on Windows. Prefer using that (the
+@rem python executable might be a shim that opens the Windows store)
+
+where.exe "py.exe"
+if %ERRORLEVEL% EQU 0 (
+    @py -3 quadplay %*
+) else (
+    @python quadplay %*
+)
+

--- a/quadplay.cmd
+++ b/quadplay.cmd
@@ -5,6 +5,7 @@ where.exe "py.exe"
 if %ERRORLEVEL% EQU 0 (
     @py -3 quadplay %*
 ) else (
+    @rem Python 3 is called "python" on Windows(!)
     @python quadplay %*
 )
 


### PR DESCRIPTION
On Windows, Python installations come with a launcher called "py.exe" by default. This launcher locates Python interpreters and allows users to specify whether to use Python 2 or 3 when running scripts. It's generally more robust than launching "python.exe" directly. Here is a page with documentation describing the launcher: https://www.python.org/dev/peps/pep-0397/.

This commit modifies "quadplay.cmd" to check if "py.exe" is present in the user's path, and uses it to run the quadplay Python script if it is. This allows users who have both Python 2 and 3 installations and rely on "py.exe" to launch quadplay. Without this change, quadplay accidentally launches the "python.exe" Windows Store shim and silently exits.