### PR TITLE
Fixing missing tkinter Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ and the following freely-available software.
 
 _Required_:
 
+- On some Distributions you might need to install `tkinter`, e.g. on Fedora `sudo dnf install -y python3-tkinter`
 - [**This SDK**](https://github.com/morgan3d/quadplay/archive/main.zip), which includes the IDE and assets
 - [**Python 3.10**](https://www.python.org/downloads/)
 - A **modern web browser** such as Chrome, Edge, Brave, Safari, or Firefox


### PR DESCRIPTION
I ran into this problem on Fedora 38 beta

```
 $ ./quadplay 
Traceback (most recent call last):
  File "/home/erik/Downloads/quadplay-main/tools/quadplay-server.py", line 58, in <module>
    import os, time, platform, sys, threading, socket, argparse, multiprocessing, json, ssl, codecs, glob, shutil, re, base64, random, getpass, inspect, subprocess, workjson, signal, shlex, tkinter, tkinter.messagebox, urllib, urllib.request
ModuleNotFoundError: No module named 'tkinter'
```