### PR TITLE
Fix paths to markdeep in documentation templates

### DIFF
--- a/console/templates/design.md.html
+++ b/console/templates/design.md.html
@@ -43,5 +43,5 @@ body, .md a { font-family: Verdana, Arial }
 em.asterisk { font-style: normal; font-weight: bold; }
 </style>
 
-<!-- Markdeep: --><script src="doc/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?"></script>
+<!-- Markdeep: --><script src="/src/quadplay/doc/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?"></script>
 

--- a/console/templates/empty.md.html
+++ b/console/templates/empty.md.html
@@ -2,5 +2,5 @@
                            **Title**
 
 
-<!-- Markdeep: --><script src="doc/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?"></script>
+<!-- Markdeep: --><script src="/src/quadplay/doc/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?"></script>
 

--- a/console/templates/todo.md.html
+++ b/console/templates/todo.md.html
@@ -14,5 +14,5 @@ Change Log
 
 [x] Already done
 
-<!-- Markdeep: --><script src="doc/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?"></script>
+<!-- Markdeep: --><script src="/src/quadplay/doc/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js?"></script>
 


### PR DESCRIPTION
I noticed this error when I tried to use the builtin documentation templates:
```
.../todo.md.html:17  GET http://127.0.0.1:8000/doc/markdeep.min.js net::ERR_ABORTED 403 (Illegal webpath (731): /doc/markdeep.min.js)
```

I switched the markdeep path from `/doc/markdeep.min.js` to `/src/quadplay/doc/markdeep.min.js` (the same path used by the manual), and that fixed the error.

Also, I saw a second error related to markdeep:
```
todo.md.html:17  GET https://casual-effects.com/markdeep/latest/markdeep.min.js? net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep 200 (OK)
```
This looks like some sort of CORS error. I'm not very familiar with CORS, so I didn't try to fix that issue.